### PR TITLE
Security Updates (Feb 08, 2023)

### DIFF
--- a/vscode4teaching-extension/package-lock.json
+++ b/vscode4teaching-extension/package-lock.json
@@ -6098,9 +6098,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -13673,9 +13673,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jszip": {

--- a/vscode4teaching-extension/package-lock.json
+++ b/vscode4teaching-extension/package-lock.json
@@ -12,7 +12,7 @@
 				"axios": "^1.1.3",
 				"form-data": "^4.0.0",
 				"ignore": "^5.1.6",
-				"jszip": "~3.7.0",
+				"jszip": "~3.8.0",
 				"lodash.escaperegexp": "^4.1.2",
 				"mkdirp": "^1.0.4",
 				"vsls": "^1.0.4753",
@@ -6110,9 +6110,9 @@
 			}
 		},
 		"node_modules/jszip": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-			"integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.8.0.tgz",
+			"integrity": "sha512-cnpQrXvFSLdsR9KR5/x7zdf6c3m8IhZfZzSblFEHSqBaVwD2nvJ4CuCKLyvKvwBgZm08CgfSoiTBQLm5WW9hGw==",
 			"dependencies": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -13679,9 +13679,9 @@
 			"dev": true
 		},
 		"jszip": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-			"integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.8.0.tgz",
+			"integrity": "sha512-cnpQrXvFSLdsR9KR5/x7zdf6c3m8IhZfZzSblFEHSqBaVwD2nvJ4CuCKLyvKvwBgZm08CgfSoiTBQLm5WW9hGw==",
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",

--- a/vscode4teaching-extension/package.json
+++ b/vscode4teaching-extension/package.json
@@ -419,7 +419,7 @@
 		"axios": "^1.1.3",
 		"form-data": "^4.0.0",
 		"ignore": "^5.1.6",
-		"jszip": "~3.7.0",
+		"jszip": "~3.8.0",
 		"lodash.escaperegexp": "^4.1.2",
 		"mkdirp": "^1.0.4",
 		"vsls": "^1.0.4753",


### PR DESCRIPTION
Includes PRs #123 #124 #125 #126 #127

- VSCode Extension (``/vscode4teaching-extension``)
  - ``jszip`` to ``3.8.0``
  - ``json5`` to ``2.2.3``
- Angular Web Application (``/vscode4teaching-webapp``)
  - ``http-cache-semantics`` to ``4.1.1``
  - ``ua-parser-js`` to ``0.7.33``
  - ``json5`` to ``2.2.3``